### PR TITLE
Update rbase64 encode usage

### DIFF
--- a/examples/Esp8266-http/esp8266_wifi.h
+++ b/examples/Esp8266-http/esp8266_wifi.h
@@ -124,8 +124,9 @@ void doRequest(WiFiClientSecure* client, boolean isGet, String postData) {
 }
 
 void sendTelemetry(String data) {
+  rbase64.encode(data);
   String postdata =
-      String("{\"binary_data\": \"") + rbase64.encode(data) + String("\"}");
+      String("{\"binary_data\": \"") + rbase64.result() + String("\"}");
 
   WiFiClientSecure client;
   doRequest(&client, false, postdata);


### PR DESCRIPTION
Based on the [documentation](https://github.com/boseji/rBASE64#example-1--using-the-standard-object) proper usage of `rbase64` for encoding seems to be:
```
rbase64.encode("Hello world");
rbase64.result();
```

I realized this was the case after the gcloud api was returning 4xx.