### PR TITLE
Fixed incorrect topic name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Core for testing on your Arduino device:
 Create the PubSub topic and subscription:
 
     gcloud pubsub topics create atest-pub --project=YOUR_PROJECT_ID
-    gcloud pubsub subscriptions create atest-sub --topic=atest--pub
+    gcloud pubsub subscriptions create atest-sub --topic=atest-pub
 
 Create the Cloud IoT Core registry:
 


### PR DESCRIPTION
Command incorrectly refers to the topic name as "atest--pub" when it's actually "atest-pub".  

Not a huge deal, but it causes an error if you're copying commands directly.