### PR TITLE
Pass MQTTClient return value to callers of publish wrappers.

### DIFF
--- a/src/CloudIoTCoreMqtt.cpp
+++ b/src/CloudIoTCoreMqtt.cpp
@@ -50,29 +50,29 @@ void CloudIoTCoreMqtt::startMQTT() {
   this->mqttClient->onMessage(messageReceived);
 }
 
-void CloudIoTCoreMqtt::publishTelemetry(String data) {
-  this->mqttClient->publish(device->getEventsTopic(), data);
+bool CloudIoTCoreMqtt::publishTelemetry(String data) {
+  return this->mqttClient->publish(device->getEventsTopic(), data);
 }
 
-void CloudIoTCoreMqtt::publishTelemetry(const char* data, int length) {
-  this->mqttClient->publish(device->getEventsTopic().c_str(), data, length);
+bool CloudIoTCoreMqtt::publishTelemetry(const char* data, int length) {
+  return this->mqttClient->publish(device->getEventsTopic().c_str(), data, length);
 }
 
-void CloudIoTCoreMqtt::publishTelemetry(String subtopic, String data) {
-  this->mqttClient->publish(device->getEventsTopic() + subtopic, data);
+bool CloudIoTCoreMqtt::publishTelemetry(String subtopic, String data) {
+  return this->mqttClient->publish(device->getEventsTopic() + subtopic, data);
 }
 
-void CloudIoTCoreMqtt::publishTelemetry(String subtopic, const char* data, int length) {
-  this->mqttClient->publish(String(device->getEventsTopic() + subtopic).c_str(), data, length);
+bool CloudIoTCoreMqtt::publishTelemetry(String subtopic, const char* data, int length) {
+  return this->mqttClient->publish(String(device->getEventsTopic() + subtopic).c_str(), data, length);
 }
 
 // Helper that just sends default sensor
-void CloudIoTCoreMqtt::publishState(String data) {
-  this->mqttClient->publish(device->getStateTopic(), data);
+bool CloudIoTCoreMqtt::publishState(String data) {
+  return this->mqttClient->publish(device->getStateTopic(), data);
 }
 
-void CloudIoTCoreMqtt::publishState(const char* data, int length) {
-  this->mqttClient->publish(device->getStateTopic().c_str(), data, length);
+bool CloudIoTCoreMqtt::publishState(const char* data, int length) {
+  return this->mqttClient->publish(device->getStateTopic().c_str(), data, length);
 }
 
 void CloudIoTCoreMqtt::onConnect() {

--- a/src/CloudIoTCoreMqtt.h
+++ b/src/CloudIoTCoreMqtt.h
@@ -40,12 +40,12 @@ class CloudIoTCoreMqtt {
     CloudIoTCoreMqtt(MQTTClient *mqttClient, Client *netClient, CloudIoTCoreDevice *device);
 
     void startMQTT();
-    void publishTelemetry(String data);
-    void publishTelemetry(const char* data, int length);
-    void publishTelemetry(String subtopic, String data);
-    void publishTelemetry(String subtopic, const char* data, int length);
-    void publishState(String data);
-    void publishState(const char* data, int length);
+    bool publishTelemetry(String data);
+    bool publishTelemetry(const char* data, int length);
+    bool publishTelemetry(String subtopic, String data);
+    bool publishTelemetry(String subtopic, const char* data, int length);
+    bool publishState(String data);
+    bool publishState(const char* data, int length);
     void onConnect();
     void setLogConnect(boolean enabled);
     void setUseLts(boolean enabled);


### PR DESCRIPTION
arduino-mqtt MQTTClient, which this is a wrapper of, returns false if it is
unable to send the message (not connected, lwmqtt_publish returned an error).
We should pass this indicator to the caller.

If lwmqtt_publish returned an error code it can be accessed through MQTTClient
lastError().