### PR TITLE
Passing skip parameter to MQTTClient::connect()

### DIFF
--- a/src/CloudIoTCoreMqtt.cpp
+++ b/src/CloudIoTCoreMqtt.cpp
@@ -162,11 +162,11 @@ void CloudIoTCoreMqtt::logReturnCode() {
   }
 }
 
-void CloudIoTCoreMqtt::mqttConnect() {
+void CloudIoTCoreMqtt::mqttConnect(bool skip) {
   Serial.print("\nconnecting...");
   bool keepgoing = true;
   while (keepgoing) {
-    this->mqttClient->connect(device->getClientId().c_str(), "unused", getJwt().c_str(), false);
+    this->mqttClient->connect(device->getClientId().c_str(), "unused", getJwt().c_str(), skip);
 
     if (this->mqttClient->lastError() != LWMQTT_SUCCESS){
       logError();

--- a/src/CloudIoTCoreMqtt.h
+++ b/src/CloudIoTCoreMqtt.h
@@ -51,6 +51,6 @@ class CloudIoTCoreMqtt {
     void setUseLts(boolean enabled);
     void logError();
     void logReturnCode();
-    void mqttConnect();
+    void mqttConnect(bool skip = false);
 };
 #endif // __CLOUDIOTCORE_MQTT_H__


### PR DESCRIPTION
With passing the skip parameter, it would be possible to do the TLS connection outside of the mqtt client. Which is useful in case of intense certificate handling for example. 

Maybe this clarifies, what I mean: https://github.com/256dpi/arduino-mqtt/issues/169

I can now for example switch between the two google LTS rootCAs.

```cpp
device = new CloudIoTCoreDevice(project_id, location, registry_id,
                                device_id, private_key_str);
mqttClient = new MQTTClient(512);
mqttClient->setOptions(180, true, 1000); // keepAlive, cleanSession, timeout
netClient = new WiFiClientSecure();
netClient->setCACert (root_cert_lts);
mqtt = new CloudIoTCoreMqtt(mqttClient, netClient, device);
mqtt->setUseLts(true);
mqtt->startMQTT();

// Establish LTS Connection
int ret = netClient->connect(CLOUD_IOT_CORE_MQTT_HOST_LTS, (uint16_t) CLOUD_IOT_CORE_MQTT_PORT);
if(ret == 0 && netClient->lastError(nullptr, 0) == -9984){
  DEBUG_MSG("Problem with Root CA. Trying backup.");
  netClient->setCACert (root_cert_lts_backup);
}
ret = netClient->connect(CLOUD_IOT_CORE_MQTT_HOST_LTS, (uint16_t) CLOUD_IOT_CORE_MQTT_PORT);
if(ret == 0 && netClient->lastError(nullptr, 0) == -9984){
  DEBUG_MSG("Again problem with Root CA. Cancel.");
  return false;
}
if (ret == 0) {
  DEBUG_MSG("Problem with WIFIClientSecure. Error Code: " + String(ret));
  return false;
}
mqtt->mqttConnect(true);
```