### PR TITLE
corrected return type of wrapper functions for telemetry publishing

### DIFF
--- a/examples/Esp32-lwmqtt/esp32-mqtt.h
+++ b/examples/Esp32-lwmqtt/esp32-mqtt.h
@@ -85,20 +85,20 @@ void connectWifi() {
 ///////////////////////////////
 // Orchestrates various methods from preceeding code.
 ///////////////////////////////
-void publishTelemetry(String data) {
-  mqtt->publishTelemetry(data);
+bool publishTelemetry(String data) {
+  return mqtt->publishTelemetry(data);
 }
 
-void publishTelemetry(const char* data, int length) {
-  mqtt->publishTelemetry(data, length);
+bool publishTelemetry(const char* data, int length) {
+  return mqtt->publishTelemetry(data, length);
 }
 
-void publishTelemetry(String subfolder, String data) {
-  mqtt->publishTelemetry(subfolder, data);
+bool publishTelemetry(String subfolder, String data) {
+  return mqtt->publishTelemetry(subfolder, data);
 }
 
-void publishTelemetry(String subfolder, const char* data, int length) {
-  mqtt->publishTelemetry(subfolder, data, length);
+bool publishTelemetry(String subfolder, const char* data, int length) {
+  return mqtt->publishTelemetry(subfolder, data, length);
 }
 
 void connect() {

--- a/examples/Esp8266-lwmqtt/esp8266_mqtt.h
+++ b/examples/Esp8266-lwmqtt/esp8266_mqtt.h
@@ -136,24 +136,24 @@ void connectWifi()
 ///////////////////////////////
 // Orchestrates various methods from preceeding code.
 ///////////////////////////////
-void publishTelemetry(String data)
+bool publishTelemetry(String data)
 {
-  mqtt->publishTelemetry(data);
+  return mqtt->publishTelemetry(data);
 }
 
-void publishTelemetry(const char *data, int length)
+bool publishTelemetry(const char *data, int length)
 {
-  mqtt->publishTelemetry(data, length);
+  return mqtt->publishTelemetry(data, length);
 }
 
-void publishTelemetry(String subfolder, String data)
+bool publishTelemetry(String subfolder, String data)
 {
-  mqtt->publishTelemetry(subfolder, data);
+  return mqtt->publishTelemetry(subfolder, data);
 }
 
-void publishTelemetry(String subfolder, const char *data, int length)
+bool publishTelemetry(String subfolder, const char *data, int length)
 {
-  mqtt->publishTelemetry(subfolder, data, length);
+  return mqtt->publishTelemetry(subfolder, data, length);
 }
 
 void connect()

--- a/examples/MKR1000-lwmqtt/mkr1000-mqtt.h
+++ b/examples/MKR1000-lwmqtt/mkr1000-mqtt.h
@@ -81,20 +81,20 @@ void connectWifi() {
 ///////////////////////////////
 // Orchestrates various methods from preceeding code.
 ///////////////////////////////
-void publishTelemetry(String data) {
-  mqtt->publishTelemetry(data);
+bool publishTelemetry(String data) {
+  return mqtt->publishTelemetry(data);
 }
 
-void publishTelemetry(const char* data, int length) {
-  mqtt->publishTelemetry(data, length);
+bool publishTelemetry(const char* data, int length) {
+  return mqtt->publishTelemetry(data, length);
 }
 
-void publishTelemetry(String subfolder, String data) {
-  mqtt->publishTelemetry(subfolder, data);
+bool publishTelemetry(String subfolder, String data) {
+  return mqtt->publishTelemetry(subfolder, data);
 }
 
-void publishTelemetry(String subfolder, const char* data, int length) {
-  mqtt->publishTelemetry(subfolder, data, length);
+bool publishTelemetry(String subfolder, const char* data, int length) {
+  return mqtt->publishTelemetry(subfolder, data, length);
 }
 
 void connect() {

--- a/examples/complex/esp32/camera/esp32-mqtt.h
+++ b/examples/complex/esp32/camera/esp32-mqtt.h
@@ -78,20 +78,20 @@ void connectWifi() {
 ///////////////////////////////
 // Orchestrates various methods from preceeding code.
 ///////////////////////////////
-void publishTelemetry(String data) {
-  mqtt->publishTelemetry(data);
+bool publishTelemetry(String data) {
+  return mqtt->publishTelemetry(data);
 }
 
-void publishTelemetry(const char* data, int length) {
-  mqtt->publishTelemetry(data, length);
+bool publishTelemetry(const char* data, int length) {
+  return mqtt->publishTelemetry(data, length);
 }
 
-void publishTelemetry(String subfolder, String data) {
-  mqtt->publishTelemetry(subfolder, data);
+bool publishTelemetry(String subfolder, String data) {
+  return mqtt->publishTelemetry(subfolder, data);
 }
 
-void publishTelemetry(String subfolder, const char* data, int length) {
-  mqtt->publishTelemetry(subfolder, data, length);
+bool publishTelemetry(String subfolder, const char* data, int length) {
+  return mqtt->publishTelemetry(subfolder, data, length);
 }
 
 void connect() {

--- a/examples/universal-lwmqtt/universal-mqtt.h
+++ b/examples/universal-lwmqtt/universal-mqtt.h
@@ -91,11 +91,11 @@ void connect() {
   mqtt->mqttConnect();
 }
 
-bool punlishTelemetry(String data) {
+bool publishTelemetry(String data) {
   return return mqtt->publishTelemetry(data);
 }
 
-bool punlishTelemetry(String subfolder, String data) {
+bool publishTelemetry(String subfolder, String data) {
   return mqtt->publishTelemetry(subfolder, data);
 }
 
@@ -177,11 +177,11 @@ void connectWifi() {
 ///////////////////////////////
 // Orchestrates various methods from preceeding code.
 ///////////////////////////////
-bool punlishTelemetry(String data) {
+bool publishTelemetry(String data) {
   return mqtt->publishTelemetry(data);
 }
 
-bool punlishTelemetry(String subfolder, String data) {
+bool publishTelemetry(String subfolder, String data) {
   return mqtt->publishTelemetry(subfolder, data);
 }
 
@@ -297,19 +297,19 @@ void connectWifi() {
 ///////////////////////////////
 // Orchestrates various methods from preceeding code.
 ///////////////////////////////
-bool punlishTelemetry(String data) {
+bool publishTelemetry(String data) {
   return mqtt->publishTelemetry(data);
 }
 
-bool punlishTelemetry(const char* data, int length) {
+bool publishTelemetry(const char* data, int length) {
   return mqtt->publishTelemetry(data, length);
 }
 
-bool punlishTelemetry(String subfolder, String data) {
+bool publishTelemetry(String subfolder, String data) {
   return mqtt->publishTelemetry(subfolder, data);
 }
 
-bool punlishTelemetry(String subfolder, const char* data, int length) {
+bool publishTelemetry(String subfolder, const char* data, int length) {
   return mqtt->publishTelemetry(subfolder, data, length);
 }
 

--- a/examples/universal-lwmqtt/universal-mqtt.h
+++ b/examples/universal-lwmqtt/universal-mqtt.h
@@ -91,12 +91,12 @@ void connect() {
   mqtt->mqttConnect();
 }
 
-void publishTelemetry(String data) {
-  mqtt->publishTelemetry(data);
+bool punlishTelemetry(String data) {
+  return return mqtt->publishTelemetry(data);
 }
 
-void publishTelemetry(String subfolder, String data) {
-  mqtt->publishTelemetry(subfolder, data);
+bool punlishTelemetry(String subfolder, String data) {
+  return mqtt->publishTelemetry(subfolder, data);
 }
 
 void setupCloudIoT() {
@@ -177,12 +177,12 @@ void connectWifi() {
 ///////////////////////////////
 // Orchestrates various methods from preceeding code.
 ///////////////////////////////
-void publishTelemetry(String data) {
-  mqtt->publishTelemetry(data);
+bool punlishTelemetry(String data) {
+  return mqtt->publishTelemetry(data);
 }
 
-void publishTelemetry(String subfolder, String data) {
-  mqtt->publishTelemetry(subfolder, data);
+bool punlishTelemetry(String subfolder, String data) {
+  return mqtt->publishTelemetry(subfolder, data);
 }
 
 void connect() {
@@ -297,20 +297,20 @@ void connectWifi() {
 ///////////////////////////////
 // Orchestrates various methods from preceeding code.
 ///////////////////////////////
-void publishTelemetry(String data) {
-  mqtt->publishTelemetry(data);
+bool punlishTelemetry(String data) {
+  return mqtt->publishTelemetry(data);
 }
 
-void publishTelemetry(const char* data, int length) {
-  mqtt->publishTelemetry(data, length);
+bool punlishTelemetry(const char* data, int length) {
+  return mqtt->publishTelemetry(data, length);
 }
 
-void publishTelemetry(String subfolder, String data) {
-  mqtt->publishTelemetry(subfolder, data);
+bool punlishTelemetry(String subfolder, String data) {
+  return mqtt->publishTelemetry(subfolder, data);
 }
 
-void publishTelemetry(String subfolder, const char* data, int length) {
-  mqtt->publishTelemetry(subfolder, data, length);
+bool punlishTelemetry(String subfolder, const char* data, int length) {
+  return mqtt->publishTelemetry(subfolder, data, length);
 }
 
 void connect() {


### PR DESCRIPTION
in all the examples, inside publishTelemetry
calls mqtt->publishTelemetry(data);  
these functions have a return type of boolean which was wrapped with void types.