### PR TITLE
Prepare for Release

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Google Cloud IoT Core JWT
-version=1.1.10
+version=1.1.11
 author=Vladimir Korukov <mrvladimir@gusclass.com>
 maintainer=Gus Class <github@gusclass.com>
 sentence=Demonstrates JWT generation for connecting Arduino clients to Google Cloud IoT Core.


### PR DESCRIPTION
We'll need to increment the library version before pressing release notes and rolling out the release to Arduino.