### PR TITLE
Update supported hardware category

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ SLA/SLO, and should not be used in production.**
 
 Currently, we support the following hardware targets:
 
-* Genuino MKR1000 and WiFi101
+* Genuino MKR1000 and WiFi1010
 * Espressif ESP32
 * Espressif ESP8266
 


### PR DESCRIPTION
Hi! 👋🏽 
There is nothing saying "Genuino WiFi 101" instead there was [Genuino WiFi 101 shield](https://store.arduino.cc/usa/arduino-wifi-101-shield) which has been deprecated and receives no support. 
So I have added one 0 "zero" to make it [Genuino WiFi 1010](https://store.arduino.cc/usa/mkr-wifi-1010) which is currently under support from the official Arduino team. 

Hope this PR gets merged soon. 🙂 

Thanks
Arijit (arijitdas18022006@gmail.com)