### PR TITLE
Fix cypher for SSL error in ESP32-lwmqtt example

### DIFF
--- a/examples/Esp32-lwmqtt/ciotc_config.h
+++ b/examples/Esp32-lwmqtt/ciotc_config.h
@@ -55,34 +55,23 @@ const int jwt_exp_secs = 60*20; // Maximum 24H (3600*24)
 // Copy the certificate (all lines between and including ---BEGIN CERTIFICATE---
 // and --END CERTIFICATE--) to root.cert and put here on the root_cert variable.
 
+// Alternatively, get Google's minimal root CA set for mqtt.2030.ltsapis.goog.
+// https://cloud.google.com/iot/docs/how-tos/mqtt-bridge#downloading_mqtt_server_certificates
+//   wget https://pki.goog/gtsltsr/gtsltsr.crt
+//   openssl x509 -inform DER -in gtsltsr.crt -out primary.pem -text
+
 const char *root_cert =
     "-----BEGIN CERTIFICATE-----\n"
-    "MIIErjCCA5agAwIBAgIQW+5sTJWKajts11BgHkBRwjANBgkqhkiG9w0BAQsFADBU\n"
-    "MQswCQYDVQQGEwJVUzEeMBwGA1UEChMVR29vZ2xlIFRydXN0IFNlcnZpY2VzMSUw\n"
-    "IwYDVQQDExxHb29nbGUgSW50ZXJuZXQgQXV0aG9yaXR5IEczMB4XDTE5MDYxMTEy\n"
-    "MzE1OVoXDTE5MDkwMzEyMjAwMFowbTELMAkGA1UEBhMCVVMxEzARBgNVBAgMCkNh\n"
-    "bGlmb3JuaWExFjAUBgNVBAcMDU1vdW50YWluIFZpZXcxEzARBgNVBAoMCkdvb2ds\n"
-    "ZSBMTEMxHDAaBgNVBAMME21xdHQuZ29vZ2xlYXBpcy5jb20wggEiMA0GCSqGSIb3\n"
-    "DQEBAQUAA4IBDwAwggEKAoIBAQDHuQUoDZWl2155WvaQ9AmhTRNC+mHassokdQK7\n"
-    "NxkZVZfrS8EhRkZop6SJGHdvozBP3Ko3g1MgGIZFzqb5fRohkRKB6mteHHi/W7Uo\n"
-    "7d8+wuTTz3llUZ2gHF/hrXFJfztwnaZub/KB+fXwSqWgMyo1EBme4ULV0rQZGFu6\n"
-    "7U38HK+mFRbeJkh1SDOureI2dxkC4ACGiqWfX/vSyzpZkWGRuxK2F5cnBHqRbcKs\n"
-    "OfmYyUuxZjGah+fC5ePgDbAntLUuYNppkdgT8yt/13ae/V7+rRhKOZC4q76HBEaQ\n"
-    "4Wn5UC+ShVaAGuo7BtfoIFSyZi8/DU2eTQcHWewIXU6V5InhAgMBAAGjggFhMIIB\n"
-    "XTATBgNVHSUEDDAKBggrBgEFBQcDATA4BgNVHREEMTAvghNtcXR0Lmdvb2dsZWFw\n"
-    "aXMuY29tghhtcXR0LW10bHMuZ29vZ2xlYXBpcy5jb20waAYIKwYBBQUHAQEEXDBa\n"
-    "MC0GCCsGAQUFBzAChiFodHRwOi8vcGtpLmdvb2cvZ3NyMi9HVFNHSUFHMy5jcnQw\n"
-    "KQYIKwYBBQUHMAGGHWh0dHA6Ly9vY3NwLnBraS5nb29nL0dUU0dJQUczMB0GA1Ud\n"
-    "DgQWBBSKWpFfG/yH1dkkJT05y/ZnRm/M4DAMBgNVHRMBAf8EAjAAMB8GA1UdIwQY\n"
-    "MBaAFHfCuFCaZ3Z2sS3ChtCDoH6mfrpLMCEGA1UdIAQaMBgwDAYKKwYBBAHWeQIF\n"
-    "AzAIBgZngQwBAgIwMQYDVR0fBCowKDAmoCSgIoYgaHR0cDovL2NybC5wa2kuZ29v\n"
-    "Zy9HVFNHSUFHMy5jcmwwDQYJKoZIhvcNAQELBQADggEBAKMoXHxmLI1oKnraV0tL\n"
-    "NzznlVnle4ljS/pqNI8LUM4/5QqD3qGqnI4fBxX1l+WByCitbTiNvL2KRNi9xau5\n"
-    "oqvsuSVkjRQxky2eesjkdrp+rrxTwFhQ6NAbUeZgUV0zfm5XZE76kInbcukwXxAx\n"
-    "lneyQy2git0voUWTK4mipfCU946rcK3+ArcanV7EDSXbRxfjBSRBD6K+XGUhIPHW\n"
-    "brk0v1wzED1RFEHTdzLAecU50Xwic6IniM3B9URfSOmjlBRebg2sEVQavMHbzURg\n"
-    "94aDC+EkNlHh3pOmQ/V89MBiF1xDHbZZ1gB0GszYKPHec9omSwQ5HbIDV3uf3/DQ\n"
-    "his=\n"
+    "MIIBxTCCAWugAwIBAgINAfD3nVndblD3QnNxUDAKBggqhkjOPQQDAjBEMQswCQYD\n"
+    "VQQGEwJVUzEiMCAGA1UEChMZR29vZ2xlIFRydXN0IFNlcnZpY2VzIExMQzERMA8G\n"
+    "A1UEAxMIR1RTIExUU1IwHhcNMTgxMTAxMDAwMDQyWhcNNDIxMTAxMDAwMDQyWjBE\n"
+    "MQswCQYDVQQGEwJVUzEiMCAGA1UEChMZR29vZ2xlIFRydXN0IFNlcnZpY2VzIExM\n"
+    "QzERMA8GA1UEAxMIR1RTIExUU1IwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAATN\n"
+    "8YyO2u+yCQoZdwAkUNv5c3dokfULfrA6QJgFV2XMuENtQZIG5HUOS6jFn8f0ySlV\n"
+    "eORCxqFyjDJyRn86d+Iko0IwQDAOBgNVHQ8BAf8EBAMCAYYwDwYDVR0TAQH/BAUw\n"
+    "AwEB/zAdBgNVHQ4EFgQUPv7/zFLrvzQ+PfNA0OQlsV+4u1IwCgYIKoZIzj0EAwID\n"
+    "SAAwRQIhAPKuf/VtBHqGw3TUwUIq7TfaExp3bH7bjCBmVXJupT9FAiBr0SmCtsuk\n"
+    "miGgpajjf/gFigGM34F9021bCWs1MbL0SA==\n"
     "-----END CERTIFICATE-----\n";
 
 // In case we ever need extra topics

--- a/examples/Esp32-lwmqtt/esp32-mqtt.h
+++ b/examples/Esp32-lwmqtt/esp32-mqtt.h
@@ -32,7 +32,7 @@ void messageReceived(String &topic, String &payload){
 ///////////////////////////////
 
 // Initialize WiFi and MQTT for this board
-Client *netClient;
+WiFiClientSecure *netClient;
 CloudIoTCoreDevice *device;
 CloudIoTCoreMqtt *mqtt;
 MQTTClient *mqttClient;
@@ -110,6 +110,7 @@ void setupCloudIoT(){
 
   setupWifi();
   netClient = new WiFiClientSecure();
+  netClient->setCACert(root_cert);
   mqttClient = new MQTTClient(512);
   mqttClient->setOptions(180, true, 1000); // keepAlive, cleanSession, timeout
   mqtt = new CloudIoTCoreMqtt(mqttClient, netClient, device);

--- a/src/CloudIoTCoreMqtt.cpp
+++ b/src/CloudIoTCoreMqtt.cpp
@@ -76,7 +76,7 @@ void CloudIoTCoreMqtt::mqttConnect(bool skip) {
     } else {
       Serial.println(mqttClient->connected() ? "connected" : "not connected");
       if (!mqttClient->connected()) {
-        Serial.println("Settings incorrect or missing a cyper for SSL");
+        Serial.println("Settings incorrect or missing a cypher for SSL");
         mqttClient->disconnect();
         logConfiguration(false);
         skip = false;
@@ -134,7 +134,7 @@ void CloudIoTCoreMqtt::mqttConnectAsync(bool skip) {
   } else {
     Serial.println(mqttClient->connected() ? "connected" : "not connected");
     if (!mqttClient->connected()) {
-      Serial.println("No internet or Settings incorrect or missing a cyper for SSL");
+      Serial.println("No internet or Settings incorrect or missing a cypher for SSL");
       mqttClient->disconnect();
       logConfiguration(false);
       skip = false;


### PR DESCRIPTION
Hi.
As shown in #221, the current ESP32-lwmqtt example gives a cypher for SSL error.
In this PR, I will fix this problem by modifying root_cert and setting root_cert to WiFiClientSecure instance.
This solution is mentioned in https://github.com/GoogleCloudPlatform/google-cloud-iot-arduino/issues/221#issuecomment-817110811 .

Thank you.

```
[E][WiFiClientSecure.cpp:133] connect(): start_ssl_client: -1
not connected
Settings incorrect or missing a cyper for SSL
Connect with mqtt.2030.ltsapis.goog:8883
ClientId: projects/***
Waiting 60 seconds, retry will likely fail
```